### PR TITLE
make getRecordInfo options optional

### DIFF
--- a/packages/recorder-react-demo/package.json
+++ b/packages/recorder-react-demo/package.json
@@ -6,7 +6,7 @@
     "@daybrush/utils": "^1.10.2",
     "@scena/react-store": "^0.2.1",
     "@scenejs/effects": "^1.0.1",
-    "@scenejs/recorder": "~0.15.0",
+    "@scenejs/recorder": "~0.16.0",
     "dom-to-image-more": "^2.13.1",
     "html-to-image": "^1.11.2",
     "react-scenejs": "^2.0.0-beta.10",

--- a/packages/recorder/package.json
+++ b/packages/recorder/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@scenejs/recorder",
-    "version": "0.15.0",
+    "version": "0.16.0",
     "description": "Make a movie of CSS animation through Scene.js for browser",
     "main": "./dist/recorder.cjs.js",
     "module": "./dist/recorder.esm.js",

--- a/packages/recorder/src/Recorder.ts
+++ b/packages/recorder/src/Recorder.ts
@@ -302,7 +302,7 @@ export class Recorder extends EventEmitter<{
      * Get the information to be recorded through options.
      * @sort 1
      */
-    public getRecordInfo(options: RecordInfoOptions) {
+    public getRecordInfo(options: RecordInfoOptions = {}) {
         const animator = this._animator;
         const inputIteration = options.iteration;
         const inputDuration = options.duration || 0;

--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -15,7 +15,7 @@
         "@ffmpeg/core": "^0.11.0",
         "@ffmpeg/ffmpeg": "^0.11.6",
         "@scena/event-emitter": "^1.0.5",
-        "@scenejs/recorder": "~0.15.0",
+        "@scenejs/recorder": "~0.16.0",
         "@types/puppeteer": "^5.4.5",
         "args": "^5.0.1",
         "fluent-ffmpeg": "^2.1.2",


### PR DESCRIPTION
This should not affect the runtime at all, due to the fact that the [`RecordInfoOptions`](https://github.com/daybrush/scenejs-render/blob/9b7b67e934e74ec3c034b7976e66272b52af53ef/packages/recorder/src/types.ts#L72-L95) has no required properties. This will have an effect on the built type declaration, making it possible to call [`Recorder.getRecordInfo()`](https://github.com/daybrush/scenejs-render/blob/9b7b67e934e74ec3c034b7976e66272b52af53ef/packages/recorder/src/Recorder.ts#L305-L352) without any argument. Previously, an empty object needed to be provided.