### PR TITLE
correct url-catching regex

### DIFF
--- a/packages/render/package.json
+++ b/packages/render/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@scenejs/render",
-    "version": "0.16.0",
+    "version": "0.17.0",
     "description": "Make a movie of CSS animation through Scene.js for node",
     "main": "./dist/render.cjs.js",
     "module": "./dist/render.esm.js",

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -75,7 +75,7 @@ async function render(options: RenderOptions = {}) {
     } = options;
     let path;
 
-    if (inputPath.match(/https*:\/\//g)) {
+    if (inputPath.match(/https?:\/\//g)) {
         path = inputPath;
     } else {
         path = url.pathToFileURL(pathModule.resolve(process.cwd(), inputPath)).href;

--- a/packages/render/src/render.ts
+++ b/packages/render/src/render.ts
@@ -75,7 +75,7 @@ async function render(options: RenderOptions = {}) {
     } = options;
     let path;
 
-    if (inputPath.match(/https?:\/\//g)) {
+    if (inputPath.match(/^https?:\/\//)) {
         path = inputPath;
     } else {
         path = url.pathToFileURL(pathModule.resolve(process.cwd(), inputPath)).href;


### PR DESCRIPTION
Fixed regex to match its intended purpose.
The previous regex would mark following examples as valid urls:
* `httpsssssssssssssssssssss://www.google.com/`
* `www.google.com/http://`